### PR TITLE
Allow optional NextState getTarget() model input

### DIFF
--- a/Flow/NextState.php
+++ b/Flow/NextState.php
@@ -59,7 +59,7 @@ class NextState implements NextStateInterface
     /**
      * {@inheritdoc}
      */
-    public function getTarget(ModelInterface $model)
+    public function getTarget(ModelInterface $model = null)
     {
         return $this->target;
     }


### PR DESCRIPTION
Since the NextState does not rely on the model to return the target, this will make the method consistent with functionality before the NextStateOr class was introduced.
