### PR TITLE
Mark Doctrine as a hard dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,7 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/symfony": "~2.0",
-        "doctrine/common": "~2.2"
-    },
-    "require-dev": {
-        "doctrine/orm": ">=2.2,<2.5-dev"
+        "doctrine/orm": "~2.2"
     },
     "autoload": {
         "psr-0": { "Lexik\\Bundle\\WorkflowBundle": "" }


### PR DESCRIPTION
In a Propel-backed project, there's no way of using the bundle. So, why not require Doctrine explicitly?
