### PR TITLE
Fix bug when $state === null

### DIFF
--- a/Handler/ProcessHandler.php
+++ b/Handler/ProcessHandler.php
@@ -192,7 +192,7 @@ class ProcessHandler implements ProcessHandlerInterface
     {
         $state = $this->getCurrentState($model);
 
-        return ( $state->getSuccessful() && in_array($state->getStepName(), $this->process->getEndSteps()) );
+        return ( $state !== null && $state->getSuccessful() && in_array($state->getStepName(), $this->process->getEndSteps()) );
     }
 
     /**


### PR DESCRIPTION
When isProcessComplete is called with a new model, the $state will be equal null, and it bug.